### PR TITLE
Create faux backend for testing.

### DIFF
--- a/content/ApiProvider.js
+++ b/content/ApiProvider.js
@@ -1,37 +1,61 @@
-angular.module(GOLFPRO).provider('apiService', [ function() {
+angular.module(GOLFPRO).provider('apiService', ['$locationProvider', function($locationProvider) {
 	var isDebug = window.isDebug;
-	var service = {
-		getPromise: function(httpMethod, resourcePath, body) {
-			var lambda = new AWS.Lambda();
-			var params = {
-				FunctionName: LAMBDA_FUNCTION,
-				//ClientContext: 'STRING_VALUE',
-				InvocationType: 'RequestResponse',
-				LogType: 'None',
-				Payload: JSON.stringify({
-					httpMethod: httpMethod,
-					resourcePath: resourcePath,
-					body: body || {}
-				})
-			};
-			//if(!isDebug()) { params.Qualifier = 'PROD'; }
+	this.$get = ['$location', '$http', function($location, $http) {
+		var host = $location.host();
+		if (host.match(/serify/)) {
+			return {
+				getPromise: function(httpMethod, resourcePath, body) {
+					var lambda = new AWS.Lambda();
+					var params = {
+						FunctionName: LAMBDA_FUNCTION,
+						//ClientContext: 'STRING_VALUE',
+						InvocationType: 'RequestResponse',
+						LogType: 'None',
+						Payload: JSON.stringify({
+							httpMethod: httpMethod,
+							resourcePath: resourcePath,
+							body: body || {}
+						})
+					};
+					//if(!isDebug()) { params.Qualifier = 'PROD'; }
 
-			return Promise.resolve()
-			.then(function() {
-				//console.log(JSON.stringify({Title: 'ApiProvider Execute Start', Now: new Date().toISOString(), Info: params }, null, 2));
-				return lambda.invoke(params).promise();
-			})
-			.then(function(data) {
-				var result = JSON.parse(data.Payload);
-				if(data.StatusCode != 200 || result.statusCode != 200) {
-					//console.log(JSON.stringify({Title: '===> End (Failure)', result: data, Now: new Date().toISOString()}, null, 2));
-					return Promise.reject(result);
+					return Promise.resolve()
+					.then(function() {
+						//console.log(JSON.stringify({Title: 'ApiProvider Execute Start', Now: new Date().toISOString(), Info: params }, null, 2));
+						return lambda.invoke(params).promise();
+					})
+					.then(function(data) {
+						var result = JSON.parse(data.Payload);
+						if(data.StatusCode != 200 || result.statusCode != 200) {
+							//console.log(JSON.stringify({Title: '===> End (Failure)', result: data, Now: new Date().toISOString()}, null, 2));
+							return Promise.reject(result);
+						}
+						//console.log(JSON.stringify({Title: '===> End', Now: new Date().toISOString()}, null, 2));
+						return result.body;
+					});
 				}
-				//console.log(JSON.stringify({Title: '===> End', Now: new Date().toISOString()}, null, 2));
-				return result.body;
-			});
+			};
 		}
-	};
-
-	this.$get = function() { return service; };
+		else {
+			return {
+				getPromise: function(httpMethod, resourcePath, body) {
+					return Promise.resolve($http({
+						method: httpMethod,
+						url: 'http://localhost:8080/api' + resourcePath,
+						data: body
+					}).then(function(response) {
+						if(response.status != 200) {
+							return Promise.reject(response.data);
+						}
+						return Promise.resolve(response.data);
+					}, function(response) {
+						if(response && response.status && response.status != 200) {
+							return Promise.reject(response.data);
+						}
+						return Promise.reject({ title: 'failed to connect', data: response });
+					}));
+				}
+			};
+		}
+	}];
 }]);

--- a/content/EventHandler.js
+++ b/content/EventHandler.js
@@ -42,10 +42,11 @@ angular.module(GOLFPRO).provider('eventHandler', ['apiServiceProvider', 'pageSer
 							UserGuid: userGuid
 						}
 					};
-					if(window.document.location.hostname === 'localhost') {
+					var host = window.document.location.hostname;
+					if (host.match(/serify/)) { return $http(compositeLogObject); }
+					else {
 						console.log(JSON.stringify(compositeLogObject, null, 2));
 					}
-					return $http(compositeLogObject);
 				})
 				.catch(function(error) {
 					console.error(JSON.stringify({Title: 'Event captured failed', Error: error.stack || error.toString(), Detail: error}, null, 2));

--- a/make.js
+++ b/make.js
@@ -21,11 +21,23 @@ commander.version(version);
 var packageMetadataFile = path.join(__dirname, 'package.json');
 var packageMetadata = require(packageMetadataFile);
 
+var apiOptions = {
+	sourceDirectory: path.join(__dirname, 'src'),
+	description: 'This is the description of the lambda function',
+	regions: ['us-east-1'],
+	runtime: 'nodejs4.3',
+	memorySize: 128,
+	publish: true,
+	timeout: 3,
+	securityGroupIds: [],
+	subnetIds: []
+};
+
 var contentOptions = {
 	bucket: 'health-verify-service',
 	contentDirectory: path.join(__dirname, 'content')
 };
-var awsArchitect = new AwsArchitect(packageMetadata, null, contentOptions);
+var awsArchitect = new AwsArchitect(packageMetadata, apiOptions, contentOptions);
 
 commander
 	.command('build')

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "deploy": "node make.js deploy",
     "test": "mocha tests/**/*.js -R spec"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "aws-architect": "^3.3.201",
     "aws-sdk": "^2.2.32",
@@ -21,6 +20,7 @@
     "esprima": "^2.7.2",
     "glob": "^5.0.0",
     "jshint": "^2.9.4",
+    "jsonwebtoken": "^7.3.0",
     "jwk-to-pem": "^1.2.6",
     "mocha": "^2.5.3",
     "openapi-factory": "^2.0.82",

--- a/package.json
+++ b/package.json
@@ -9,17 +9,21 @@
     "deploy": "node make.js deploy",
     "test": "mocha tests/**/*.js -R spec"
   },
-  "dependencies": {},
+  "dependencies": {
+  },
   "devDependencies": {
     "aws-architect": "^3.3.201",
     "aws-sdk": "^2.2.32",
+    "axios": "^0.15.3",
     "chai": "^3.2.0",
     "ci-build-tools": "~1.0",
     "commander": "^2.5.0",
     "esprima": "^2.7.2",
     "glob": "^5.0.0",
     "jshint": "^2.9.4",
+    "jwk-to-pem": "^1.2.6",
     "mocha": "^2.5.3",
+    "openapi-factory": "^2.0.82",
     "sinon": "^1.17.1"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,85 @@
+const aws = require('aws-sdk');
+const Api = require('openapi-factory');
+const jwtManager = require('jsonwebtoken');
+const jwkConverter = require('jwk-to-pem');
+const axios = require('axios');
+
+module.exports = api = new Api();
+
+let localUserId = "us-east-1:localUser";
+let links = [
+    {
+        "UserId": localUserId,
+        "Base64Hash": "dW5kZWZpbmVkOnVuZGVmaW5lZDp1cy1lYXN0LTE6NjJlYjY4ZGUtZTExYi00Y2E3LWJjM2ItYTA3Yjc0ZjYwMWFj",
+        currentLink: true
+    }
+];
+api.get('/link', (event, context) => {
+    return new Api.Response(links[0], 200, { 'Content-Type': 'application/json' });
+});
+api.post('/link', (event, context) => {
+    return new Api.Response(links.find(l => l.currentLink).Base64Hash, 200, { 'Content-Type': 'application/json' });
+});
+api.get('/links', (event, context) => {
+    return new Api.Response(links, 200, { 'Content-Type': 'application/json' });
+});
+
+let users = [
+    {
+        userId: localUserId,
+		UserId: localUserId,
+        userData: {},
+        Verifications: [],
+        verifications: [],
+        admin: true
+    }
+];
+api.get('/user', (event, context) => {
+    return new Api.Response(users[0], 200, { 'Content-Type': 'application/json' });
+});
+api.put('/user', (event, context) => {
+    return new Api.Response({}, 200, { 'Content-Type': 'application/json' });
+});
+let verifications = [];
+api.post('/user/verifications', (event, context) => {
+    verifications.push({
+        Info: event.body,
+        Status: 'NEW'
+    });
+    return new Api.Response({}, 200, { 'Content-Type': 'application/json' });
+});
+api.put('/user/data', (event, context) => {
+    return new Api.Response({}, 200, { 'Content-Type': 'application/json' });
+});
+api.get('/verifications', (event, context) => {
+    return new Api.Response([], 200, { 'Content-Type': 'application/json' });
+});
+api.post('/verifications', (event, context) => {
+    return new Api.Response({}, 200, { 'Content-Type': 'application/json' });
+});
+api.post('/event', (event, context) => {
+    return new Api.Response({}, 200, { 'Content-Type': 'application/json' });
+});
+api.get('/summary', (event, context) => {
+    return new Api.Response({}, 200, { 'Content-Type': 'application/json' });
+});
+let feedbackData = {
+    feedbackList: [
+        {
+            time: new Date(),
+            information: {
+                username: 'me'
+            }
+        }
+    ]
+};
+api.get('/feedback', (event, context) => {
+    return new Api.Response(feedbackData, 200, { 'Content-Type': 'application/json' });
+});
+api.post('/feedback', (event, context) => {
+    feedbackData.feedbackList.push({
+        time: new Date(),
+        information: event.body
+    });
+    return new Api.Response({}, 200, { 'Content-Type': 'application/json' });
+});


### PR DESCRIPTION
Should be able to run `npm start`, and not worry about hitting production.  Right now most of the endpoints don't work perfectly, but it is better than anything else.  If you need to test against production, for now, the switch is in the `apiProvider.js` "class".