### PR TITLE
Get user details from link.

### DIFF
--- a/content/LinkManager.js
+++ b/content/LinkManager.js
@@ -24,14 +24,4 @@ angular.module(SERIFYAPP).service('linkManager', [ 'apiService', 'loginStatusPro
 			});
 		});
 	};
-	this.GetAllUserLinks = function() {
-		return apiService.getPromise('GET', '/links', {})
-		.catch(function(failure) {
-			console.error(JSON.stringify({Title: 'Failed to get all links for user', Error: failure.stack || failure.toString(), Detail: failure}, null, 2));
-			return Promise.reject({
-				Error: 'Failed to get all links for user.',
-				Detail: failure
-			});
-		});
-	};
 }]);

--- a/content/UserManager.js
+++ b/content/UserManager.js
@@ -24,12 +24,10 @@ angular.module(SERIFYAPP).service('userManager', [ 'apiService', 'loginStatusPro
 			});
 		});
 	};
-	this.GetUserDataPromise = function(userId) {
-		return apiService.getPromise('GET', '/user', {
-			user: userId
-		})
+	this.GetUserDataPromise = function() {
+		return apiService.getPromise('GET', '/user', {})
 		.catch(function(failure) {
-			console.error(JSON.stringify({Title: 'Failed to get user', UserId: userId, Error: failure.stack || failure.toString(), Detail: failure}, null, 2));
+			console.error(JSON.stringify({Title: 'Failed to get current user', Error: failure.stack || failure.toString(), Detail: failure}, null, 2));
 			return Promise.reject({
 				Error: 'Unable to get user profile, please try again later.',
 				Detail: failure

--- a/content/view/view.html
+++ b/content/view/view.html
@@ -4,14 +4,14 @@
   <h5 class="mb-0"><a ng-click="voteButtonClick()">Help us go live, Vote Here!</a></h5>
 </div>
 <div class="publicProfile">
-	<div ng-show="linkname && !error" class="do-not-animate">
+	<div ng-show="user && !error" class="do-not-animate">
 			<h4 id="publicProfileUsername">{{username}}</h4>
 	</div>
-	<div id="publicProfileInfo" ng-show="linkname && !error">
+	<div id="publicProfileInfo" ng-show="user && !error">
 		{{profile}}
 		<hr>
 	</div>
-	<div ng-show="!linkname && !error" class="do-not-animate">
+	<div ng-show="!user && !error" class="do-not-animate">
 			<h4 id="publicProfileUsername">Retrieving Profile...</h4>
 	</div>
 	<div ng-show="error" class="do-not-animate">
@@ -20,7 +20,7 @@
 	<div>
 		<div class="row clearfix">
 			<div class="col-md-12 column">
-				<table id="publicProfileTable" class="table" ng-show="linkname && !error">
+				<table id="publicProfileTable" class="table" ng-show="user && !error">
 					<thead>
 						<tr>
 							<th class="col-xs-7 col-sm-4 tableTopText text-center">Test</th>

--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,10 @@ let links = [
     }
 ];
 api.get('/link', (event, context) => {
-    return new Api.Response(links[0], 200, { 'Content-Type': 'application/json' });
+    return new Api.Response(users[0], 200, { 'Content-Type': 'application/json' });
 });
 api.post('/link', (event, context) => {
     return new Api.Response(links.find(l => l.currentLink).Base64Hash, 200, { 'Content-Type': 'application/json' });
-});
-api.get('/links', (event, context) => {
-    return new Api.Response(links, 200, { 'Content-Type': 'application/json' });
 });
 
 let verifications = [
@@ -61,7 +58,10 @@ let users = [
     {
         userId: localUserId,
 		UserId: localUserId,
-        userData: {},
+        userData: {
+            username: 'Tester Username',
+            profile: 'This is the test profile'
+        },
         Verifications: verifications,
         verifications: verifications,
         admin: true


### PR DESCRIPTION
For clarifications, the link provider returns all the necessary user information should be provided with that link, looking up the data from the usermanager is unnecessary.

Additionally this closes a future problem, if users want to deactivate a link or give different permissions to each link.