### PR TITLE
remove failure on ios 8.

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -53,7 +53,7 @@
 		<!-- End Google Analytics -->
 
 	</head>
-	<body ng-controller="navController" ng-style="isPublicProfile() ? {'background': '#f5f8fa'} : {'background': 'white'}">
+	<body ng-controller="navController" style="background: #f5f8fa">
 		<nav ng-cloak ng-show="finishedLoading" class="navbar navbar-default">
 	        <div ng-cloak class="container-fluid">
 	            <!-- Brand and toggle get grouped for better mobile display -->

--- a/content/index.js
+++ b/content/index.js
@@ -108,10 +108,6 @@ function($scope, $rootScope, $routeParams, $location, $uibModal, loginStatusProv
 		return viewLocation === pageService.GetCurrentPage();
 	};
 
-	$scope.isPublicProfile = function() {
-		return pageService.GetCurrentPage().includes('/view');
-	};
-
 	/******** SignInButton Block ********/
 	$rootScope.authentication.IsAdmin = false;
 	$rootScope.authentication.UserAuthenticated = false;


### PR DESCRIPTION
`includes` doesn't work for some reason, and we shouldn't have different colors per pages.  It makes sense to just remove this.